### PR TITLE
Incorrect/useless MaxActiveAmount behavior?

### DIFF
--- a/marginbot.go
+++ b/marginbot.go
@@ -101,7 +101,8 @@ func strategyMarginBot(bconf BotConfig, dryRun bool) (err error) {
 
 	// Check if we need to limit our usage
 	if bconf.Bitfinex.MaxActiveAmount >= 0 {
-		available = math.Min(available, bconf.Bitfinex.MaxActiveAmount)
+		available = math.Min(available, math.Min(available + bconf.Bitfinex.MaxActiveAmount - walletAmount, bconf.Bitfinex.MaxActiveAmount))
+
 	}
 
 	loanOffers := marginBotGetLoanOffers(available, minLoan, lendbook, conf)


### PR DESCRIPTION
Before MaxActiveAmount was limiting the lending amount of current iteration, basically just delaying the rest of the amount. Not sure why would someone use it...
I propose to use it to limit total lendable amount. I find it useful.
