### PR TITLE
Scheduling is not robust enough

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To run the Bot every 10 minutes with cron (`$ crontab -e`) use:
 Alternatively, to run in GNU Screen or similar use:
 
 ```bash
-while [[ 1 ]]; do BitfinexLendingBot --updatelends --logtofile; sleep 10m; done
+while [[ 1 ]]; do timeout 30s BitfinexLendingBot --updatelends --logtofile; sleep 10m; done
 ```
 
 # Configuration


### PR DESCRIPTION
I was running a loop in GNU Screen and for some reason bot froze (bug?), so the cycle never resumed. Better time it out.

The cron is also doesn't work out of the box (at least on Ubuntu), lockrun is not a standard tool.
